### PR TITLE
Sync CHANGELOG with Marketplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Change Log
 
-## Version 0.0.4
+## Version 0.0.5
 
 - Add settings to configure what information is displayed: `showBin`, `showHex`, `showDec`, `showStr`, `showSize` (by Oswin Rodrigues)
+
+## Version 0.0.4
+
+Add `zh-cn` and `zh-tw` translations.
 
 ## Version 0.0.3
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bit-peek",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bit-peek",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.7",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bit-peek",
   "displayName": "Bit Peek",
   "description": "Display the binary and other forms of numbers in a very easy to read format.",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "publisher": "dingzhaojie",
   "engines": {
     "vscode": "^1.40.0"


### PR DESCRIPTION
## Minor Fix

I just noticed the VS Code Marketplace's [CHANGELOG](https://marketplace.visualstudio.com/items/dingzhaojie.bit-peek/changelog) already has a `0.0.4` version (see [history here](https://marketplace.visualstudio.com/items?itemName=dingzhaojie.bit-peek&ssr=false#version-history)) and was out of sync with the repository's.